### PR TITLE
Add a script to upgrade the Elasticsearch version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ buildNumber.properties
 
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
 !/.mvn/wrapper/maven-wrapper.jar
+
+# vim
+*.swp

--- a/README.md
+++ b/README.md
@@ -88,4 +88,7 @@ Upgrade Elasticsearch version, e.g 7.8.0 -> 7.10.0:
 
 ```sh
 > scripts/upgrade-es-version.sh 7.8.0 7.10.0
+✅ pom.xml
+✅ cluster/src/test/resources/docker-compose.yml
+Finished.
 ```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ unexpected.
 
 The fastest way to test any basic Elasticsearch feature is to start a Docker image with the desired Elasticsearch version:
 
+<!-- MANAGED_BLOCK_RUN_ES_START -->
+
 ```sh
 docker run \
   --rm \
@@ -16,6 +18,8 @@ docker run \
   -p 9200:9200 \
   docker.elastic.co/elasticsearch/elasticsearch:7.8.0
 ```
+
+<!-- MANAGED_BLOCK_RUN_ES_END -->
 
 ## Articles
 

--- a/README.md
+++ b/README.md
@@ -81,3 +81,11 @@ Articles:
   <https://blog.twitter.com/engineering/en_us/topics/infrastructure/2020/reducing-search-indexing-latency-to-one-second.html>
 - Prabin Meitei M, "Garbage Collection in Elasticsearch and the G1GC", _Medium_, 2018.<br>
   <https://medium.com/naukri-engineering/garbage-collection-in-elasticsearch-and-the-g1gc-16b79a447181>
+
+## Development
+
+Upgrade Elasticsearch version, e.g 7.8.0 -> 7.10.0:
+
+```sh
+> scripts/upgrade-es-version.sh 7.8.0 7.10.0
+```

--- a/cluster/src/test/resources/docker-compose.yml
+++ b/cluster/src/test/resources/docker-compose.yml
@@ -5,7 +5,7 @@
 version: '2.2'
 services:
   es01:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.8.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.8.0  # CURRENT_ES_VERSION
     container_name: es01
     environment:
       - node.name=es01
@@ -25,7 +25,7 @@ services:
     networks:
       - elastic
   es02:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.8.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.8.0  # CURRENT_ES_VERSION
     container_name: es02
     environment:
       - node.name=es02
@@ -43,7 +43,7 @@ services:
     networks:
       - elastic
   es03:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.8.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.8.0  # CURRENT_ES_VERSION
     container_name: es03
     environment:
       - node.name=es03

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
       Elasticsearch/Lucene Version Mapping:
       https://github.com/elastic/elasticsearch/blob/master/server/src/main/java/org/elasticsearch/Version.java#L58-L76
      -->
-    <elasticsearch.version>7.8.0</elasticsearch.version>
+    <elasticsearch.version>7.8.0</elasticsearch.version><!-- CURRENT_ES_VERSION -->
     <!--
       Dependencies should be aligned with Elasticsearch Testing Framework's
       requirement. Inspect Maven dependency tree to find out the right version:

--- a/scripts/upgrade-es-version.sh
+++ b/scripts/upgrade-es-version.sh
@@ -10,11 +10,22 @@
 #
 old_version="$1"
 new_version="$2"
+
+if [[ -z $old_version || -z $new_version ]]
+then
+    echo "Missing argument(s). Usage:"
+    echo
+    echo "    upgrade-es-version.sh 7.8.0 7.10.0"
+    echo
+    exit 1
+fi
+
 filepaths=($(rg --files-with-matches --glob "**/*.{xml,yml}" CURRENT_ES_VERSION))
 
 for filepath in "${filepaths[@]}"
 do
-    echo $filepath
+    sed -i '' -e "s/${old_version}/${new_version}/g" $filepath
+    echo "${filepath} done"
 done
 
 echo "Finished."

--- a/scripts/upgrade-es-version.sh
+++ b/scripts/upgrade-es-version.sh
@@ -28,4 +28,24 @@ do
     echo "${filepath} done"
 done
 
+NEW_BLOCK=$(cat <<EOF
+<!-- MANAGED_BLOCK_RUN_ES_START -->
+
+\`\`\`sh
+docker run \\
+  --rm \\
+  -e discovery.type=single-node \\
+  -p 9200:9200 \\
+  docker.elastic.co/elasticsearch/elasticsearch:${new_version}
+\`\`\`
+
+<!-- MANAGED_BLOCK_RUN_ES_END -->
+EOF
+)
+
+start=$(grep -n MANAGED_BLOCK_RUN_ES_START README.md | cut -f 1 -d :)
+end=$(grep -n MANAGED_BLOCK_RUN_ES_END README.md | cut -f 1 -d :)
+# echo -e "$NEW_BLOCK"
+sed -i '' "${start},${end}d" README.md
+
 echo "Finished."

--- a/scripts/upgrade-es-version.sh
+++ b/scripts/upgrade-es-version.sh
@@ -2,10 +2,19 @@
 #
 # Usage:
 #
-#     scripts/upgrade-es-version.sh <new_version>
+#     scripts/upgrade-es-version.sh <old_version> <new_version>
 #
-# Sample:
+# Sample upgrading from 7.8.0 to 7.10.0:
 #
-#     scripts/upgrade-es-version.sh 7.10.0
+#     scripts/upgrade-es-version.sh 7.8.0 7.10.0
 #
+old_version="$1"
+new_version="$2"
+filepaths=($(rg --files-with-matches --glob "**/*.{xml,yml}" CURRENT_ES_VERSION))
+
+for filepath in "${filepaths[@]}"
+do
+    echo $filepath
+done
+
 echo "Finished."

--- a/scripts/upgrade-es-version.sh
+++ b/scripts/upgrade-es-version.sh
@@ -20,33 +20,17 @@ then
     exit 1
 fi
 
+# Update configuration files
 filepaths=($(rg --files-with-matches --glob "**/*.{xml,yml}" CURRENT_ES_VERSION))
-
 for filepath in "${filepaths[@]}"
 do
     sed -i '' -e "s/${old_version}/${new_version}/g" $filepath
     echo "${filepath} done"
 done
 
-NEW_BLOCK=$(cat <<EOF
-<!-- MANAGED_BLOCK_RUN_ES_START -->
-
-\`\`\`sh
-docker run \\
-  --rm \\
-  -e discovery.type=single-node \\
-  -p 9200:9200 \\
-  docker.elastic.co/elasticsearch/elasticsearch:${new_version}
-\`\`\`
-
-<!-- MANAGED_BLOCK_RUN_ES_END -->
-EOF
-)
-
+# Update README
 start=$(grep -n MANAGED_BLOCK_RUN_ES_START README.md | cut -f 1 -d :)
 end=$(grep -n MANAGED_BLOCK_RUN_ES_END README.md | cut -f 1 -d :)
-# echo -e "$NEW_BLOCK"
 sed -i '' "${start},${end}s/${old_version}/${new_version}/g" README.md
-#sed -i '' "${start}a${NEW_BLOCK}"
 
 echo "Finished."

--- a/scripts/upgrade-es-version.sh
+++ b/scripts/upgrade-es-version.sh
@@ -46,6 +46,7 @@ EOF
 start=$(grep -n MANAGED_BLOCK_RUN_ES_START README.md | cut -f 1 -d :)
 end=$(grep -n MANAGED_BLOCK_RUN_ES_END README.md | cut -f 1 -d :)
 # echo -e "$NEW_BLOCK"
-sed -i '' "${start},${end}d" README.md
+sed -i '' "${start},${end}s/${old_version}/${new_version}/g" README.md
+#sed -i '' "${start}a${NEW_BLOCK}"
 
 echo "Finished."

--- a/scripts/upgrade-es-version.sh
+++ b/scripts/upgrade-es-version.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Usage:
+#
+#     scripts/upgrade-es-version.sh <new_version>
+#
+# Sample:
+#
+#     scripts/upgrade-es-version.sh 7.10.0
+#
+echo "Finished."

--- a/scripts/upgrade-es-version.sh
+++ b/scripts/upgrade-es-version.sh
@@ -25,7 +25,7 @@ filepaths=($(rg --files-with-matches --glob "**/*.{xml,yml}" CURRENT_ES_VERSION)
 for filepath in "${filepaths[@]}"
 do
     sed -i '' -e "s/${old_version}/${new_version}/g" $filepath
-    echo "${filepath} done"
+    echo "✅ ${filepath}"
 done
 
 # Update README


### PR DESCRIPTION
This is done using markers "CURRENT_ES_VERSION", "MANAGED_BLOCK_RUN_ES_START", and "MANAGED_BLOCK_RUN_ES_END". This is inspired by the usage of "CURRENT_GRPC_VERSION" from gRPC Java client ([source code](https://github.com/grpc/grpc-java/blob/b2e475712d67a0660e1d16d6465a4ccb9b8a6b40/examples/pom.xml#L9)).