### PR TITLE
Include all DVF datasets from 2014 to 2020

### DIFF
--- a/demo-dvf/src/main/java/io/mincong/dvf/demo/ReadPathAggregationDemo.java
+++ b/demo-dvf/src/main/java/io/mincong/dvf/demo/ReadPathAggregationDemo.java
@@ -13,12 +13,13 @@ import org.elasticsearch.client.RestHighLevelClient;
 public class ReadPathAggregationDemo {
 
   private static final Logger logger = LogManager.getLogger(ReadPathAggregationDemo.class);
+  private static final int YEAR = 2020;
 
   public void run() {
     var builder = RestClient.builder(new HttpHost("localhost", 9200, "http"));
     logger.info("Start creating REST high-level client...");
     try (var restClient = new RestHighLevelClient(builder)) {
-      var aggregator = new TransactionEsAggregator(restClient);
+      var aggregator = new TransactionEsAggregator(restClient, YEAR);
 
       runMetricAggregations(aggregator);
       runBucketAggregations(aggregator);

--- a/demo-dvf/src/main/java/io/mincong/dvf/demo/WritePathDemo.java
+++ b/demo-dvf/src/main/java/io/mincong/dvf/demo/WritePathDemo.java
@@ -93,15 +93,15 @@ public class WritePathDemo {
     return esWriter
         .write(transactions)
         .whenComplete(
-            (ids, ex) -> {
+            (docCount, ex) -> {
               if (ex != null) {
                 logger.error("Failed to complete", ex);
               } else {
                 var duration = Duration.between(start, Instant.now());
-                var speed = String.format("%.2f", ids.size() * 1.0 / duration.toSeconds());
+                var speed = String.format("%.2f", docCount * 1.0 / duration.toSeconds());
                 logger.info(
                     "Finished, indexed {} documents in {} (speed: {} docs/s)",
-                    ids.size(),
+                    docCount,
                     duration,
                     speed);
               }

--- a/demo-dvf/src/main/java/io/mincong/dvf/demo/WritePathDemo.java
+++ b/demo-dvf/src/main/java/io/mincong/dvf/demo/WritePathDemo.java
@@ -197,7 +197,7 @@ public class WritePathDemo {
           restClient.snapshot().create(createSnapshotRequest, RequestOptions.DEFAULT);
       logger.info("Snapshot created: {}", createSnapshotResponse);
 
-      var deleteIndexRequest = new DeleteIndexRequest().indices("transactions");
+      var deleteIndexRequest = new DeleteIndexRequest().indices(Transaction.INDEX_NAME);
       var deletionIndexResponse =
           restClient.indices().delete(deleteIndexRequest, RequestOptions.DEFAULT);
       logger.info("Index deleted: {}", deletionIndexResponse);

--- a/demo-dvf/src/main/java/io/mincong/dvf/demo/WritePathDemo.java
+++ b/demo-dvf/src/main/java/io/mincong/dvf/demo/WritePathDemo.java
@@ -27,7 +27,16 @@ import org.elasticsearch.client.RestHighLevelClient;
 public class WritePathDemo {
   private static final Logger logger = LogManager.getLogger(WritePathDemo.class);
 
-  private static final String CSV_PATH = "/Users/minconghuang/github/dvf/downloads/full.2020.csv";
+  private static final Path[] CSV_PATHS =
+      new Path[] {
+        Path.of("/Users/minconghuang/github/dvf/downloads/full.2014.csv"),
+        Path.of("/Users/minconghuang/github/dvf/downloads/full.2015.csv"),
+        Path.of("/Users/minconghuang/github/dvf/downloads/full.2016.csv"),
+        Path.of("/Users/minconghuang/github/dvf/downloads/full.2017.csv"),
+        Path.of("/Users/minconghuang/github/dvf/downloads/full.2018.csv"),
+        Path.of("/Users/minconghuang/github/dvf/downloads/full.2019.csv"),
+        Path.of("/Users/minconghuang/github/dvf/downloads/full.2020.csv"),
+      };
 
   private static final String REPO_NAME = "dvf";
 
@@ -74,7 +83,7 @@ public class WritePathDemo {
     //    var esWriter =
     //        new TransactionSimpleEsWriter(restClient, Transaction.INDEX_NAME, RefreshPolicy.NONE);
 
-    var transactions = csvReader.readCsv(Path.of(CSV_PATH));
+    var transactions = csvReader.readCsv(CSV_PATHS);
     if (INDEX_BULK_LIMIT > 0) {
       transactions = transactions.limit(INDEX_BULK_LIMIT);
     }

--- a/demo-dvf/src/main/java/io/mincong/dvf/demo/WritePathDemo.java
+++ b/demo-dvf/src/main/java/io/mincong/dvf/demo/WritePathDemo.java
@@ -27,16 +27,7 @@ import org.elasticsearch.client.RestHighLevelClient;
 public class WritePathDemo {
   private static final Logger logger = LogManager.getLogger(WritePathDemo.class);
 
-  private static final Path[] CSV_PATHS =
-      new Path[] {
-        Path.of("/Users/minconghuang/github/dvf/downloads/full.2014.csv"),
-        Path.of("/Users/minconghuang/github/dvf/downloads/full.2015.csv"),
-        Path.of("/Users/minconghuang/github/dvf/downloads/full.2016.csv"),
-        Path.of("/Users/minconghuang/github/dvf/downloads/full.2017.csv"),
-        Path.of("/Users/minconghuang/github/dvf/downloads/full.2018.csv"),
-        Path.of("/Users/minconghuang/github/dvf/downloads/full.2019.csv"),
-        Path.of("/Users/minconghuang/github/dvf/downloads/full.2020.csv"),
-      };
+  private static final String DVF_DOWNLOADS_DIR = "/Users/minconghuang/github/dvf/downloads/";
 
   /**
    * Specify which years should be included in the write path demo. The program will read the
@@ -103,7 +94,8 @@ public class WritePathDemo {
     //    var esWriter =
     //        new TransactionSimpleEsWriter(restClient, Transaction.INDEX_NAME, RefreshPolicy.NONE);
 
-    var transactions = csvReader.readCsv(CSV_PATHS);
+    var path = Path.of(DVF_DOWNLOADS_DIR, String.format("full.%d.csv", year));
+    var transactions = csvReader.readCsv(path);
     if (INDEX_BULK_LIMIT > 0) {
       transactions = transactions.limit(INDEX_BULK_LIMIT);
     }

--- a/demo-dvf/src/main/java/io/mincong/dvf/model/Transaction.java
+++ b/demo-dvf/src/main/java/io/mincong/dvf/model/Transaction.java
@@ -1,5 +1,6 @@
 package io.mincong.dvf.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -14,7 +15,7 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableTransaction.class)
 public abstract class Transaction {
 
-  public static final String INDEX_NAME = "transactions";
+  private static final String INDEX_NAME = "transactions";
 
   public static final String FIELD_MUTATION_ID = "mutation_id";
 
@@ -240,5 +241,12 @@ public abstract class Transaction {
 
   static {
     mappings.put("location", Map.of("type", "geo_point"));
+  }
+
+  /* ----- JSON unrelated methods ----- */
+
+  @JsonIgnore
+  public static String indexNameForYear(int year) {
+    return INDEX_NAME + "." + year;
   }
 }

--- a/demo-dvf/src/main/java/io/mincong/dvf/model/Transaction.java
+++ b/demo-dvf/src/main/java/io/mincong/dvf/model/Transaction.java
@@ -14,7 +14,7 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableTransaction.class)
 public abstract class Transaction {
 
-  public static final String INDEX_NAME = "transactions";
+  public static final String INDEX_NAME = "transactions.2014-2020";
 
   public static final String FIELD_MUTATION_ID = "mutation_id";
 

--- a/demo-dvf/src/main/java/io/mincong/dvf/model/Transaction.java
+++ b/demo-dvf/src/main/java/io/mincong/dvf/model/Transaction.java
@@ -14,7 +14,7 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableTransaction.class)
 public abstract class Transaction {
 
-  public static final String INDEX_NAME = "transactions.2014-2020";
+  public static final String INDEX_NAME = "transactions";
 
   public static final String FIELD_MUTATION_ID = "mutation_id";
 

--- a/demo-dvf/src/main/java/io/mincong/dvf/service/EsWriter.java
+++ b/demo-dvf/src/main/java/io/mincong/dvf/service/EsWriter.java
@@ -8,9 +8,9 @@ import java.util.stream.Stream;
 public interface EsWriter {
   void createIndex();
 
-  default CompletableFuture<List<String>> write(ImmutableTransaction... items) {
+  default CompletableFuture<Long> write(ImmutableTransaction... items) {
     return write(Stream.of(List.of(items)));
   }
 
-  CompletableFuture<List<String>> write(Stream<List<ImmutableTransaction>> items);
+  CompletableFuture<Long> write(Stream<List<ImmutableTransaction>> items);
 }

--- a/demo-dvf/src/main/java/io/mincong/dvf/service/TransactionCsvReader.java
+++ b/demo-dvf/src/main/java/io/mincong/dvf/service/TransactionCsvReader.java
@@ -12,9 +12,12 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class TransactionCsvReader {
 
+  private static final Logger logger = LogManager.getLogger(TransactionCsvReader.class);
   private final ObjectReader objectReader;
   private final int bulkSize;
 
@@ -31,6 +34,7 @@ public class TransactionCsvReader {
             path -> {
               Iterator<ImmutableTransactionRow> iterator;
               try {
+                logger.info("Reading file {}", path);
                 iterator = objectReader.readValues(path.toFile());
               } catch (IOException e) {
                 throw new IllegalStateException("Failed to read file " + path, e);

--- a/demo-dvf/src/main/java/io/mincong/dvf/service/TransactionEsAggregator.java
+++ b/demo-dvf/src/main/java/io/mincong/dvf/service/TransactionEsAggregator.java
@@ -38,9 +38,11 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 public class TransactionEsAggregator {
   private static final Logger logger = LogManager.getLogger(TransactionEsAggregator.class);
   private final RestHighLevelClient restClient;
+  private final int year;
 
-  public TransactionEsAggregator(RestHighLevelClient restClient) {
+  public TransactionEsAggregator(RestHighLevelClient restClient, int year) {
     this.restClient = restClient;
+    this.year = year;
   }
 
   /**
@@ -73,7 +75,8 @@ public class TransactionEsAggregator {
             .aggregation(AggregationBuilders.count(aggregationName).field(fieldName))
             .query(QueryBuilders.matchAllQuery());
 
-    var request = new SearchRequest().indices(Transaction.INDEX_NAME).source(sourceBuilder);
+    var request =
+        new SearchRequest().indices(Transaction.indexNameForYear(year)).source(sourceBuilder);
 
     try {
       var response = restClient.search(request, RequestOptions.DEFAULT);
@@ -152,7 +155,8 @@ public class TransactionEsAggregator {
             .size(0)
             .query(query);
 
-    var request = new SearchRequest().indices(Transaction.INDEX_NAME).source(sourceBuilder);
+    var request =
+        new SearchRequest().indices(Transaction.indexNameForYear(year)).source(sourceBuilder);
 
     try {
       var response = restClient.search(request, RequestOptions.DEFAULT);
@@ -242,7 +246,8 @@ public class TransactionEsAggregator {
                 AggregationBuilders.percentiles(percentilesAggregationName).field(fieldName))
             .query(query);
 
-    var request = new SearchRequest().indices(Transaction.INDEX_NAME).source(sourceBuilder);
+    var request =
+        new SearchRequest().indices(Transaction.indexNameForYear(year)).source(sourceBuilder);
 
     SearchResponse response;
     try {
@@ -274,7 +279,8 @@ public class TransactionEsAggregator {
             .aggregation(AggregationBuilders.stats(statsAggregationName).field(fieldName))
             .query(query);
 
-    var request = new SearchRequest().indices(Transaction.INDEX_NAME).source(sourceBuilder);
+    var request =
+        new SearchRequest().indices(Transaction.indexNameForYear(year)).source(sourceBuilder);
 
     SearchResponse response;
     try {
@@ -336,7 +342,8 @@ public class TransactionEsAggregator {
             .aggregation(termsAggregation)
             .query(query);
 
-    var request = new SearchRequest().indices(Transaction.INDEX_NAME).source(sourceBuilder);
+    var request =
+        new SearchRequest().indices(Transaction.indexNameForYear(year)).source(sourceBuilder);
 
     SearchResponse response;
     try {
@@ -416,7 +423,8 @@ public class TransactionEsAggregator {
             .aggregation(termsAggregation)
             .query(query);
 
-    var request = new SearchRequest().indices(Transaction.INDEX_NAME).source(sourceBuilder);
+    var request =
+        new SearchRequest().indices(Transaction.indexNameForYear(year)).source(sourceBuilder);
 
     SearchResponse response;
     try {
@@ -469,7 +477,8 @@ public class TransactionEsAggregator {
                 AggregationBuilders.terms("postal_code/terms").field("postal_code").size(3))
             .query(QueryBuilders.matchAllQuery());
 
-    var request = new SearchRequest().indices(Transaction.INDEX_NAME).source(sourceBuilder);
+    var request =
+        new SearchRequest().indices(Transaction.indexNameForYear(year)).source(sourceBuilder);
 
     SearchResponse response;
     try {

--- a/demo-dvf/src/main/java/io/mincong/dvf/service/TransactionSimpleEsWriter.java
+++ b/demo-dvf/src/main/java/io/mincong/dvf/service/TransactionSimpleEsWriter.java
@@ -41,7 +41,7 @@ public class TransactionSimpleEsWriter implements EsWriter {
   }
 
   @Override
-  public CompletableFuture<List<String>> write(Stream<List<ImmutableTransaction>> transactions) {
+  public CompletableFuture<Long> write(Stream<List<ImmutableTransaction>> transactions) {
     var cfs = transactions.flatMap(List::stream).map(this::index).collect(Collectors.toList());
     return CompletableFuture.allOf(cfs.toArray(CompletableFuture[]::new))
         .thenApply(
@@ -52,7 +52,7 @@ public class TransactionSimpleEsWriter implements EsWriter {
                   ids.addAll(cf.join());
                 }
               }
-              return ids;
+              return (long) ids.size();
             });
   }
 

--- a/demo-dvf/src/test/java/io/mincong/dvf/service/TransactionBulkEsWriterIT.java
+++ b/demo-dvf/src/test/java/io/mincong/dvf/service/TransactionBulkEsWriterIT.java
@@ -28,6 +28,6 @@ public class TransactionBulkEsWriterIT extends TransactionEsWriterAbstractIT {
   @Override
   protected EsWriter newEsWriter() {
     return new TransactionBulkEsWriter(
-        restClient, Transaction.INDEX_NAME, executor, RefreshPolicy.IMMEDIATE);
+        restClient, Transaction.indexNameForYear(year), executor, RefreshPolicy.IMMEDIATE);
   }
 }

--- a/demo-dvf/src/test/java/io/mincong/dvf/service/TransactionEsAggregatorIT.java
+++ b/demo-dvf/src/test/java/io/mincong/dvf/service/TransactionEsAggregatorIT.java
@@ -31,6 +31,7 @@ public class TransactionEsAggregatorIT extends ESRestTestCase {
   private final ImmutableTransaction[] transactions = {
     TRANSACTION_1, TRANSACTION_2, TRANSACTION_3, TRANSACTION_4
   };
+  private final int year = 2020;
 
   private RestHighLevelClient restClient;
   private ExecutorService executor;
@@ -46,7 +47,7 @@ public class TransactionEsAggregatorIT extends ESRestTestCase {
     executor = Executors.newSingleThreadExecutor();
     var writer =
         new TransactionBulkEsWriter(
-            restClient, Transaction.INDEX_NAME, executor, RefreshPolicy.IMMEDIATE);
+            restClient, Transaction.indexNameForYear(year), executor, RefreshPolicy.IMMEDIATE);
     writer.createIndex();
     writer.write(transactions).get(10, SECONDS);
   }
@@ -61,7 +62,7 @@ public class TransactionEsAggregatorIT extends ESRestTestCase {
   @Test
   public void testCountValueAggregation() {
     // Given
-    var searcher = new TransactionEsAggregator(restClient);
+    var searcher = new TransactionEsAggregator(restClient, year);
 
     // When
     var valueCount = searcher.mutationIdsCount();
@@ -73,7 +74,7 @@ public class TransactionEsAggregatorIT extends ESRestTestCase {
   @Test
   public void testPostalCode() {
     // Given
-    var searcher = new TransactionEsAggregator(restClient);
+    var searcher = new TransactionEsAggregator(restClient, year);
 
     // When
     var stats = searcher.mutationsByPostalCode();

--- a/demo-dvf/src/test/java/io/mincong/dvf/service/TransactionEsAggregatorIT.java
+++ b/demo-dvf/src/test/java/io/mincong/dvf/service/TransactionEsAggregatorIT.java
@@ -48,7 +48,7 @@ public class TransactionEsAggregatorIT extends ESRestTestCase {
         new TransactionBulkEsWriter(
             restClient, Transaction.INDEX_NAME, executor, RefreshPolicy.IMMEDIATE);
     writer.createIndex();
-    writer.write(transactions).get(10, SECONDS).forEach(id -> logger.info("Transaction " + id));
+    writer.write(transactions).get(10, SECONDS);
   }
 
   @After

--- a/demo-dvf/src/test/java/io/mincong/dvf/service/TransactionEsWriterAbstractIT.java
+++ b/demo-dvf/src/test/java/io/mincong/dvf/service/TransactionEsWriterAbstractIT.java
@@ -7,8 +7,7 @@ import io.mincong.dvf.model.ImmutableTransaction;
 import io.mincong.dvf.model.Transaction;
 import org.apache.http.HttpHost;
 import org.assertj.core.api.Assertions;
-import org.elasticsearch.action.get.MultiGetItemResponse;
-import org.elasticsearch.action.get.MultiGetRequest;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
@@ -62,16 +61,18 @@ public abstract class TransactionEsWriterAbstractIT extends ESRestTestCase {
     writer.createIndex();
 
     // When
-    var ids = writer.write(TRANSACTION_1, TRANSACTION_2, TRANSACTION_3).get(10, SECONDS);
+    var transactions = new ImmutableTransaction[] {TRANSACTION_1, TRANSACTION_2, TRANSACTION_3};
+    var count = writer.write(transactions).get(10, SECONDS);
 
     // Then
+    Assertions.assertThat(count).isEqualTo(3L);
+
     var objectMapper = Jackson.newObjectMapper();
-    var request = new MultiGetRequest();
-    ids.forEach(id -> request.add(Transaction.INDEX_NAME, id));
-    var response = restClient.mget(request, RequestOptions.DEFAULT);
-    Assertions.assertThat(response.getResponses())
-        .extracting(MultiGetItemResponse::getResponse)
-        .extracting(r -> objectMapper.readValue(r.getSourceAsString(), ImmutableTransaction.class))
-        .containsExactlyInAnyOrder(TRANSACTION_1, TRANSACTION_2, TRANSACTION_3);
+    var request = new SearchRequest().indices(Transaction.INDEX_NAME);
+    var response = restClient.search(request, RequestOptions.DEFAULT);
+    Assertions.assertThat(response.getHits().getHits())
+        .extracting(
+            hit -> objectMapper.readValue(hit.getSourceAsString(), ImmutableTransaction.class))
+        .containsExactlyInAnyOrder(transactions);
   }
 }

--- a/demo-dvf/src/test/java/io/mincong/dvf/service/TransactionEsWriterAbstractIT.java
+++ b/demo-dvf/src/test/java/io/mincong/dvf/service/TransactionEsWriterAbstractIT.java
@@ -30,6 +30,8 @@ public abstract class TransactionEsWriterAbstractIT extends ESRestTestCase {
 
   protected abstract EsWriter newEsWriter();
 
+  protected final int year = 2020;
+
   @Before
   @Override
   public void setUp() throws Exception {
@@ -68,7 +70,7 @@ public abstract class TransactionEsWriterAbstractIT extends ESRestTestCase {
     Assertions.assertThat(count).isEqualTo(3L);
 
     var objectMapper = Jackson.newObjectMapper();
-    var request = new SearchRequest().indices(Transaction.INDEX_NAME);
+    var request = new SearchRequest().indices(Transaction.indexNameForYear(year));
     var response = restClient.search(request, RequestOptions.DEFAULT);
     Assertions.assertThat(response.getHits().getHits())
         .extracting(

--- a/demo-dvf/src/test/java/io/mincong/dvf/service/TransactionSimpleEsWriterIT.java
+++ b/demo-dvf/src/test/java/io/mincong/dvf/service/TransactionSimpleEsWriterIT.java
@@ -8,6 +8,6 @@ public class TransactionSimpleEsWriterIT extends TransactionEsWriterAbstractIT {
   @Override
   protected EsWriter newEsWriter() {
     return new TransactionSimpleEsWriter(
-        restClient, Transaction.INDEX_NAME, RefreshPolicy.IMMEDIATE);
+        restClient, Transaction.indexNameForYear(year), RefreshPolicy.IMMEDIATE);
   }
 }


### PR DESCRIPTION
The goal is to perform cross-year searches. Initially I want to put all the data into the index `transactions` but there are too many data (20,509,246 lines) and it's time consuming for my poor Macbook Pro Early 2015. To be more resilient about errors, I decided to divide the dataset per year. The naming convention of the index is:

```
transactions.{year}
```

This PR also replaces the list of IDs returned by the completable futures by a document count so that it reduces the memory usage of the Java program.